### PR TITLE
Make retry scheduler pluggable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 resque-retry
 ============
 
-A [Resque][resque] plugin. Requires Resque ~> 1.25 & [resque-scheduler][resque-scheduler] ~> 4.0.
+A [Resque][resque] plugin. Requires Resque ~> 1.25.
+You must also have [resque-scheduler][resque-scheduler] ~> 4.0, unless you
+implement you own `retry_scheduler`. The resque-scheudler gem is *not* a
+dependency, so you need to add it to your application manually if you do not
+already have it.
 
 This gem provides retry, delay and exponential backoff support for resque jobs.
 
@@ -582,6 +586,36 @@ Reminder: `@ignore_exceptions` should be a subset of `@retry_exceptions`.
 
 The inner-workings of the plugin are output to the Resque [Logger](https://github.com/resque/resque/wiki/Logging)
 when `Resque.logger.level` is set to `Logger::DEBUG`.
+
+
+Using without resque-scheduler
+------------------------------
+
+By default, resque-retry will schedule jobs to be retried using resque-scheduler.
+Follow these steps if you would like to use a different scheduling mechanism:
+
+### 1) Require 'resque-retry/custom_scheduler'
+
+The default `require "resque-retry"` will configure the resque-scheduler behavior.
+Instead, use:
+
+```
+# Gemfile
+
+gem "resque-retry", require: "resque-retry/custom_scheduler"
+```
+
+### 2) Provide your own retry_scheduler
+
+Create an object that implements the `retry_scheduler` interface (see
+`lib/resque/plugins/retry/retry_via_resque_scheduler.rb`).
+
+Set the `retry_scheduler` to your new object when your application starts:
+
+```
+Resque.retry_scheduler = MyCustomSchedulerLogic.new
+```
+
 
 Contributing/Pull Requests
 --------------------------

--- a/lib/resque-retry.rb
+++ b/lib/resque-retry.rb
@@ -1,15 +1,5 @@
-require 'resque'
+require 'resque-retry/custom_scheduler'
 
-require 'resque/plugins/retry'
-require 'resque/plugins/retry/extensions'
-require 'resque/plugins/exponential_backoff'
-require 'resque/failure/multiple_with_retry_suppression'
-require 'resque-retry/version.rb'
-
-Resque.extend Resque::Plugins::Retry::Extensions
-
-# Only when using resque-scheduler
 require 'resque-scheduler'
 require 'resque/plugins/retry/retry_via_resque_scheduler'
 Resque.retry_scheduler = Resque::Plugins::Retry::RetryViaResqueScheduler.new(Resque)
-

--- a/lib/resque-retry.rb
+++ b/lib/resque-retry.rb
@@ -1,8 +1,15 @@
 require 'resque'
-require 'resque-scheduler'
 
 require 'resque/plugins/retry'
+require 'resque/plugins/retry/extensions'
 require 'resque/plugins/exponential_backoff'
 require 'resque/failure/multiple_with_retry_suppression'
-
 require 'resque-retry/version.rb'
+
+Resque.extend Resque::Plugins::Retry::Extensions
+
+# Only when using resque-scheduler
+require 'resque-scheduler'
+require 'resque/plugins/retry/retry_via_resque_scheduler'
+Resque.retry_scheduler = Resque::Plugins::Retry::RetryViaResqueScheduler.new(Resque)
+

--- a/lib/resque-retry/custom_scheduler.rb
+++ b/lib/resque-retry/custom_scheduler.rb
@@ -1,0 +1,9 @@
+require 'resque'
+
+require 'resque/plugins/retry'
+require 'resque/plugins/retry/extensions'
+require 'resque/plugins/exponential_backoff'
+require 'resque/failure/multiple_with_retry_suppression'
+require 'resque-retry/version.rb'
+
+Resque.extend Resque::Plugins::Retry::Extensions

--- a/lib/resque-retry/server.rb
+++ b/lib/resque-retry/server.rb
@@ -21,7 +21,7 @@ module ResqueRetry
         end
 
         post '/retry/:timestamp/remove' do
-          Resque.delayed_timestamp_peek(params[:timestamp], 0, 0).each do |job|
+          Resque.retry_scheduler.delayed_timestamp_peek(params[:timestamp], 0, 0).each do |job|
             cancel_retry(job)
           end
           redirect u('retry')
@@ -65,9 +65,8 @@ module ResqueRetry
 
       # cancels job retry
       def cancel_retry(job)
-        klass = get_class(job)
         retry_key = retry_key_for_job(job)
-        Resque.remove_delayed(klass, *job['args'])
+        Resque.retry_scheduler.remove_delayed(job)
         Resque.redis.del("failure-#{retry_key}")
         Resque.redis.del(retry_key)
       end

--- a/lib/resque-retry/server.rb
+++ b/lib/resque-retry/server.rb
@@ -70,6 +70,10 @@ module ResqueRetry
         Resque.redis.del(retry_key)
       end
 
+      def format_retry_time(t)
+        t.strftime('%Y-%m-%d %H:%M:%S %z')
+      end
+
       private
       def get_class(job)
         Resque::Job.new(nil, nil).constantize(job['class'])

--- a/lib/resque-retry/server.rb
+++ b/lib/resque-retry/server.rb
@@ -1,6 +1,5 @@
 require 'cgi'
 require 'resque/server'
-require 'resque/scheduler/server'
 
 # Extend Resque::Server to add tabs.
 module ResqueRetry

--- a/lib/resque-retry/server/views/retry.erb
+++ b/lib/resque-retry/server/views/retry.erb
@@ -33,7 +33,7 @@
           <input type="submit" value="Queue now">
         </form>
       </td>
-      <td><a href="<%= u "retry/#{timestamp}" %>"><%= format_time(Time.at(timestamp)) %></a></td>
+      <td><a href="<%= u "retry/#{timestamp}" %>"><%= format_retry_time(Time.at(timestamp)) %></a></td>
       <td><%= delayed_timestamp_size = resque.retry_scheduler.delayed_timestamp_size(timestamp) %></td>
       <% if job && delayed_timestamp_size == 1 %>
         <td><%= h job['class'] %></td>

--- a/lib/resque-retry/server/views/retry.erb
+++ b/lib/resque-retry/server/views/retry.erb
@@ -1,4 +1,5 @@
 <h1>Delayed Jobs with Retry Information</h1>
+<% can_queue_now = defined?(Resque::Scheduler) %>
 
 <p class="intro">
   This list below contains the timestamps for scheduled delayed jobs with
@@ -28,10 +29,12 @@
         <form action="<%= u "retry/#{timestamp}/remove" %>" method="post">
           <input type="submit" value="Remove">
         </form>
+      <% if can_queue_now %>
         <form action="<%= u "/delayed/queue_now" %>" method="post">
           <input type="hidden" name="timestamp" value="<%= timestamp.to_i %>">
           <input type="submit" value="Queue now">
         </form>
+      <% end %>
       </td>
       <td><a href="<%= u "retry/#{timestamp}" %>"><%= format_retry_time(Time.at(timestamp)) %></a></td>
       <td><%= delayed_timestamp_size = resque.retry_scheduler.delayed_timestamp_size(timestamp) %></td>

--- a/lib/resque-retry/server/views/retry.erb
+++ b/lib/resque-retry/server/views/retry.erb
@@ -7,7 +7,7 @@
 
 <p class="sub">
   Showing <%= start = params[:start].to_i %> to <%= start + 20 %> of
-  <b><%= size = resque.delayed_queue_schedule_size %></b> timestamps
+  <b><%= size = resque.retry_scheduler.delayed_queue_schedule_size %></b> timestamps
 </p>
 
 <table>
@@ -19,9 +19,9 @@
     <th>Args</th>
     <th>Retry Attempts</th>
   </tr>
-  <% timestamps = resque.delayed_queue_peek(start, start+20) %>
+  <% timestamps = resque.retry_scheduler.delayed_queue_peek(start, start+20) %>
   <% timestamps.each do |timestamp| %>
-    <% job = resque.delayed_timestamp_peek(timestamp, 0, 1).first %>
+    <% job = resque.retry_scheduler.delayed_timestamp_peek(timestamp, 0, 1).first %>
     <% next unless job %>
     <tr>
       <td>
@@ -34,7 +34,7 @@
         </form>
       </td>
       <td><a href="<%= u "retry/#{timestamp}" %>"><%= format_time(Time.at(timestamp)) %></a></td>
-      <td><%= delayed_timestamp_size = resque.delayed_timestamp_size(timestamp) %></td>
+      <td><%= delayed_timestamp_size = resque.retry_scheduler.delayed_timestamp_size(timestamp) %></td>
       <% if job && delayed_timestamp_size == 1 %>
         <td><%= h job['class'] %></td>
         <td><%= h job['args'].inspect %></td>

--- a/lib/resque-retry/server/views/retry_timestamp.erb
+++ b/lib/resque-retry/server/views/retry_timestamp.erb
@@ -12,7 +12,7 @@
 
 <p class="sub">
   Showing <%= start = params[:start].to_i %> to <%= start + 20 %> of
-  <b><%= size = resque.delayed_timestamp_size(timestamp) %></b> jobs
+  <b><%= size = resque.retry_scheduler.delayed_timestamp_size(timestamp) %></b> jobs
 </p>
 
 <table class="jobs">
@@ -24,7 +24,7 @@
     <th>Backtrace</th>
     <th>Actions</th>
   </tr>
-  <% jobs = resque.delayed_timestamp_peek(timestamp, start, 20) %>
+  <% jobs = resque.retry_scheduler.delayed_timestamp_peek(timestamp, start, 20) %>
   <% jobs.each do |job| %>
     <% retry_key = retry_key_for_job(job) %>
     <% retry_attempts = retry_attempts_for_job(job) %>

--- a/lib/resque-retry/server/views/retry_timestamp.erb
+++ b/lib/resque-retry/server/views/retry_timestamp.erb
@@ -1,7 +1,7 @@
 <% timestamp = params[:timestamp].to_i %>
 
 <h1>
-  Delayed Jobs scheduled for <%= format_time(Time.at(timestamp)) %>
+  Delayed Jobs scheduled for <%= format_retry_time(Time.at(timestamp)) %>
   (with Retry Information)
 </h1>
 

--- a/lib/resque/plugins/retry.rb
+++ b/lib/resque/plugins/retry.rb
@@ -406,7 +406,7 @@ module Resque
           # If the delay is 0, no point passing it through the scheduler
           Resque.enqueue(retry_in_queue, *retry_args)
         else
-          Resque.enqueue_in(temp_retry_delay, retry_in_queue, *retry_args)
+          Resque.retry_scheduler.enqueue_in(temp_retry_delay, retry_in_queue, *retry_args)
         end
 
         # remove retry key from redis if we handed retry off to another queue.

--- a/lib/resque/plugins/retry/extensions.rb
+++ b/lib/resque/plugins/retry/extensions.rb
@@ -1,0 +1,15 @@
+module Resque
+  module Plugins
+    module Retry
+      module Extensions
+        def retry_scheduler
+          @retry_scheduler
+        end
+
+        def retry_scheduler=(val)
+          @retry_scheduler = val
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/plugins/retry/retry_via_resque_scheduler.rb
+++ b/lib/resque/plugins/retry/retry_via_resque_scheduler.rb
@@ -1,0 +1,43 @@
+module Resque
+  module Plugins
+    module Retry
+      # We could just return an instance of Resque, but this helps document
+      # the expected scheduler interface.
+      class RetryViaResqueScheduler
+        def initialize(resque)
+          @resque = resque
+        end
+
+        def enqueue_in(time_offset, job, *args)
+          @resque.enqueue_in(time_offset, job, *args)
+        end
+
+        def delayed_queue_peek(start, count)
+          @resque.delayed_queue_peek(start, count)
+        end
+
+        def delayed_timestamp_peek(timestamp, start, count)
+          @resque.delayed_timestamp_peek(timestamp, start, count)
+        end
+
+        def delayed_timestamp_size(timestamp)
+          @resque.delayed_timestamp_size(timestamp)
+        end
+
+        def delayed_queue_schedule_size
+          @resque.delayed_queue_schedule_size
+        end
+
+        def remove_delayed(job)
+          klass = get_class(job)
+          @resque.remove_delayed(klass, *job['args'])
+        end
+
+        private
+        def get_class(job)
+          Resque::Job.new(nil, nil).constantize(job['class'])
+        end
+      end
+    end
+  end
+end

--- a/resque-retry.gemspec
+++ b/resque-retry.gemspec
@@ -30,8 +30,10 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.add_dependency('resque', '~> 1.25')
-  s.add_dependency('resque-scheduler', '~> 4.0')
 
+  # resque-scheduler is required to use the default behavior, but it is
+  # not required in the gemspec, so that users can opt-out of it.
+  s.add_development_dependency('resque-scheduler', '~> 4.0')
   s.add_development_dependency('rake', '~> 10.3')
   s.add_development_dependency('minitest', '~> 5.5')
   s.add_development_dependency('rack-test', '~> 0.6')

--- a/test/retry_exception_delay_test.rb
+++ b/test/retry_exception_delay_test.rb
@@ -23,7 +23,7 @@ class RetryTest < Minitest::Test
     assert_equal 0, Resque.info[:pending], 'zero pending jobs as their delayed'
 
     # now lets see if the delays are correct?
-    delayed = Resque.delayed_queue_peek(0, 3)
+    delayed = Resque.retry_scheduler.delayed_queue_peek(0, 3)
     assert_in_delta (start_time + 7), delayed[0], 1.00, 'retry delay timestamp'
   end
 
@@ -38,7 +38,7 @@ class RetryTest < Minitest::Test
     end
 
     # now lets see if the delays are correct?
-    delayed = Resque.delayed_queue_peek(0, 3)
+    delayed = Resque.retry_scheduler.delayed_queue_peek(0, 3)
     assert_in_delta (start_time + 5),  delayed[0], 1.00, '1st retry delay timestamp'
     assert_in_delta (start_time + 10), delayed[1], 1.00, '2nd retry delay timestamp'
     assert_in_delta (start_time + 15), delayed[2], 1.00, '3rd retry delay timestamp'

--- a/test/server_helpers_test.rb
+++ b/test/server_helpers_test.rb
@@ -16,7 +16,7 @@ class ServerHelpersTest < Minitest::Test
     perform_next_job(@worker)
 
     timestamp = Resque.delayed_queue_peek(0, 1).first
-    job = Resque.delayed_timestamp_peek(timestamp, 0, 1).first
+    job = Resque.retry_scheduler.delayed_timestamp_peek(timestamp, 0, 1).first
     assert_equal '0', @helpers.retry_attempts_for_job(job), 'should have 0 retry attempt'
   end
 end


### PR DESCRIPTION
This removes the direct dependence on the resque-scheduler gem. The default behavior will still use resque-scheduler to schedule jobs to be retried in the future, but you must now bring in the resque-scheduler gem yourself, since it is no longer a gemspec dependency of resque-retry.

Alternatively, you can use your own scheduler by requiring `resque-retry/custom_scheduler` instead of `resque-retry`. You then need to set `Resque.retry_scheduler` to an object that fulfills the necessary API (see `RetryViaResqueScheduler` for an example).

